### PR TITLE
fix: FrigadeBanner default type

### DIFF
--- a/src/FrigadeBanner/index.tsx
+++ b/src/FrigadeBanner/index.tsx
@@ -29,7 +29,7 @@ import { useTheme } from '../hooks/useTheme'
 export type FrigadeBannerType = 'full-width' | 'square'
 
 export interface FrigadeBannerProps extends DefaultFrigadeFlowProps {
-  type: FrigadeBannerType
+  type?: FrigadeBannerType
 }
 
 export const FrigadeBanner: React.FC<FrigadeBannerProps> = ({


### PR DESCRIPTION
I noticed that there is a default value for `type` in `FrigadeBanner`:
https://github.com/FrigadeHQ/frigade-react/blob/0e29e0a992826f17f028acd5126b1bb8f824dbc2/src/FrigadeBanner/index.tsx#L43

That means that `type` should be optional.