### PR TITLE
fix: tour freezing entire page until dismissed

### DIFF
--- a/packages/react/src/components/Tooltip/index.tsx
+++ b/packages/react/src/components/Tooltip/index.tsx
@@ -100,7 +100,15 @@ export function Tooltip({
       <Popover.Portal>
         <div
           className={className}
-          css={{ bottom: 0, left: 0, position: 'absolute', right: 0, top: 0, zIndex: 9999 }}
+          css={{
+            bottom: 0,
+            left: 0,
+            position: 'absolute',
+            right: 0,
+            top: 0,
+            zIndex: 9999,
+            pointerEvents: 'none',
+          }}
         >
           {spotlight && (
             <Box
@@ -123,6 +131,7 @@ export function Tooltip({
               position="relative"
               css={{
                 maxWidth: '360px',
+                pointerEvents: 'auto',
                 ...style,
               }}
             >


### PR DESCRIPTION
Tested the tour in Storybook to ensure it worked as expected (text/buttons work, spotlight on/off works)