### PR TITLE
a11y fixes on Hero Checklist module

### DIFF
--- a/packages/reactv1/src/components/CheckBox/index.tsx
+++ b/packages/reactv1/src/components/CheckBox/index.tsx
@@ -114,6 +114,7 @@ export const CheckBox: FC<CheckBoxProps> = ({
       styleOverrides={checkBoxStyle}
       style={style}
       role="checkbox"
+      aria-checked={value === true} 
       className={mergeClasses(
         getClassName('checkIconContainer', appearance),
         getClassName(

--- a/packages/reactv1/src/components/CheckBox/index.tsx
+++ b/packages/reactv1/src/components/CheckBox/index.tsx
@@ -72,6 +72,7 @@ export interface CheckBoxProps {
   appearance?: Appearance
   className?: string
   style?: React.CSSProperties
+  label?: string
 }
 
 const CheckIconContainer = styled.div`
@@ -87,6 +88,7 @@ export const CheckBox: FC<CheckBoxProps> = ({
   appearance = DefaultAppearance,
   style,
   className,
+  label,
 }) => {
   let checkBoxStyle = getBaseStyle(type as CheckBoxType)
   let stateStyle = getStateStyle(type as CheckBoxType, value)
@@ -114,7 +116,8 @@ export const CheckBox: FC<CheckBoxProps> = ({
       styleOverrides={checkBoxStyle}
       style={style}
       role="checkbox"
-      aria-checked={value === true} 
+      aria-checked={value === true}
+      aria-label={label}
       className={mergeClasses(
         getClassName('checkIconContainer', appearance),
         getClassName(

--- a/packages/reactv1/src/components/CheckBoxRow/index.tsx
+++ b/packages/reactv1/src/components/CheckBoxRow/index.tsx
@@ -72,6 +72,7 @@ export const CheckBoxRow: FC<CheckBoxRowProps> = ({
           appearance={appearance}
           value={value}
           type={checkBoxType}
+          label={label}
           primaryColor={primaryColor}
         />
         {labelPosition === 'right' && label && (

--- a/packages/reactv1/src/components/Checklists/HeroChecklist/HeroChecklist.tsx
+++ b/packages/reactv1/src/components/Checklists/HeroChecklist/HeroChecklist.tsx
@@ -184,7 +184,7 @@ const HeroChecklist: FC<FrigadeChecklistProps> = ({
             appearance={appearance}
           />
         </ChecklistHeader>
-        <ChecklistStepsContainer className={getClassName('checklistStepsContainer', appearance)}>
+        <ChecklistStepsContainer role='list' className={getClassName('checklistStepsContainer', appearance)}>
           {steps.map((s: StepData, idx: number) => {
             return (
               <StepChecklistItem

--- a/packages/reactv1/src/components/Checklists/HeroChecklist/StepChecklistItem.tsx
+++ b/packages/reactv1/src/components/Checklists/HeroChecklist/StepChecklistItem.tsx
@@ -1,18 +1,18 @@
-import React, { CSSProperties, FC } from 'react';
-import { CheckBoxRow } from '../../CheckBoxRow';
-import { Appearance, StepData } from '../../../types';
-import { ChecklistStepItem, StepItemSelectedIndicator } from './styled';
-import { getClassName } from '../../../shared/appearance';
+import React, { CSSProperties, FC } from 'react'
+import { CheckBoxRow } from '../../CheckBoxRow'
+import { Appearance, StepData } from '../../../types'
+import { ChecklistStepItem, StepItemSelectedIndicator } from './styled'
+import { getClassName } from '../../../shared/appearance'
 
 interface StepItemProps {
-  data: StepData;
-  index: number;
-  listLength: number;
-  isSelected: boolean;
-  primaryColor: string;
-  style: CSSProperties;
-  onClick: () => void;
-  appearance: Appearance;
+  data: StepData
+  index: number
+  listLength: number
+  isSelected: boolean
+  primaryColor: string
+  style: CSSProperties
+  onClick: () => void
+  appearance: Appearance
 }
 
 export const StepChecklistItem: FC<StepItemProps> = ({
@@ -28,15 +28,15 @@ export const StepChecklistItem: FC<StepItemProps> = ({
     <div
       style={{ position: 'relative', paddingLeft: '0px' }}
       onClick={() => {
-        onClick();
+        onClick()
       }}
     >
       {isSelected && (
         <StepItemSelectedIndicator
           className={getClassName('checklistStepItemSelectedIndicator', appearance)}
-          layoutId="checklist-step-selected"
+          layoutId="checklis-step-selected"
           style={{ backgroundColor: appearance?.theme?.colorPrimary ?? primaryColor }}
-        />
+        ></StepItemSelectedIndicator>
       )}
       <ChecklistStepItem
         className={getClassName('checklistStepItem', appearance)}
@@ -44,17 +44,16 @@ export const StepChecklistItem: FC<StepItemProps> = ({
         appearance={appearance}
         role="listitem"
       >
-        <label style={{ display: 'inline-block', width: '100%' }}> {/* Added label wrapper */}
-          <CheckBoxRow
-            value={data.complete}
-            labelPosition="left"
-            label={data.stepName ?? data.title}
-            style={style}
-            primaryColor={appearance?.theme?.colorPrimary ?? primaryColor}
-            appearance={appearance}
-          />
-        </label>
+        <CheckBoxRow
+          value={data.complete}
+          labelPosition="left"
+          label={data.stepName ?? data.title}
+          aria-label={data.stepName ?? data.title}
+          style={style}
+          primaryColor={appearance?.theme?.colorPrimary ?? primaryColor}
+          appearance={appearance}
+        />
       </ChecklistStepItem>
     </div>
-  );
-};
+  )
+}

--- a/packages/reactv1/src/components/Checklists/HeroChecklist/StepChecklistItem.tsx
+++ b/packages/reactv1/src/components/Checklists/HeroChecklist/StepChecklistItem.tsx
@@ -34,7 +34,7 @@ export const StepChecklistItem: FC<StepItemProps> = ({
       {isSelected && (
         <StepItemSelectedIndicator
           className={getClassName('checklistStepItemSelectedIndicator', appearance)}
-          layoutId="checklis-step-selected"
+          layoutId="checklist-step-selected"
           style={{ backgroundColor: appearance?.theme?.colorPrimary ?? primaryColor }}
         ></StepItemSelectedIndicator>
       )}

--- a/packages/reactv1/src/components/Checklists/HeroChecklist/StepChecklistItem.tsx
+++ b/packages/reactv1/src/components/Checklists/HeroChecklist/StepChecklistItem.tsx
@@ -48,6 +48,7 @@ export const StepChecklistItem: FC<StepItemProps> = ({
           value={data.complete}
           labelPosition="left"
           label={data.stepName ?? data.title}
+          aria-label={data.stepName ?? data.title}
           style={style}
           primaryColor={appearance?.theme?.colorPrimary ?? primaryColor}
           appearance={appearance}

--- a/packages/reactv1/src/components/Checklists/HeroChecklist/StepChecklistItem.tsx
+++ b/packages/reactv1/src/components/Checklists/HeroChecklist/StepChecklistItem.tsx
@@ -1,18 +1,18 @@
-import React, { CSSProperties, FC } from 'react'
-import { CheckBoxRow } from '../../CheckBoxRow'
-import { Appearance, StepData } from '../../../types'
-import { ChecklistStepItem, StepItemSelectedIndicator } from './styled'
-import { getClassName } from '../../../shared/appearance'
+import React, { CSSProperties, FC } from 'react';
+import { CheckBoxRow } from '../../CheckBoxRow';
+import { Appearance, StepData } from '../../../types';
+import { ChecklistStepItem, StepItemSelectedIndicator } from './styled';
+import { getClassName } from '../../../shared/appearance';
 
 interface StepItemProps {
-  data: StepData
-  index: number
-  listLength: number
-  isSelected: boolean
-  primaryColor: string
-  style: CSSProperties
-  onClick: () => void
-  appearance: Appearance
+  data: StepData;
+  index: number;
+  listLength: number;
+  isSelected: boolean;
+  primaryColor: string;
+  style: CSSProperties;
+  onClick: () => void;
+  appearance: Appearance;
 }
 
 export const StepChecklistItem: FC<StepItemProps> = ({
@@ -28,15 +28,15 @@ export const StepChecklistItem: FC<StepItemProps> = ({
     <div
       style={{ position: 'relative', paddingLeft: '0px' }}
       onClick={() => {
-        onClick()
+        onClick();
       }}
     >
       {isSelected && (
         <StepItemSelectedIndicator
           className={getClassName('checklistStepItemSelectedIndicator', appearance)}
-          layoutId="checklis-step-selected"
+          layoutId="checklist-step-selected"
           style={{ backgroundColor: appearance?.theme?.colorPrimary ?? primaryColor }}
-        ></StepItemSelectedIndicator>
+        />
       )}
       <ChecklistStepItem
         className={getClassName('checklistStepItem', appearance)}
@@ -44,16 +44,17 @@ export const StepChecklistItem: FC<StepItemProps> = ({
         appearance={appearance}
         role="listitem"
       >
-        <CheckBoxRow
-          value={data.complete}
-          labelPosition="left"
-          label={data.stepName ?? data.title}
-          aria-label={data.stepName ?? data.title}
-          style={style}
-          primaryColor={appearance?.theme?.colorPrimary ?? primaryColor}
-          appearance={appearance}
-        />
+        <label style={{ display: 'inline-block', width: '100%' }}> {/* Added label wrapper */}
+          <CheckBoxRow
+            value={data.complete}
+            labelPosition="left"
+            label={data.stepName ?? data.title}
+            style={style}
+            primaryColor={appearance?.theme?.colorPrimary ?? primaryColor}
+            appearance={appearance}
+          />
+        </label>
       </ChecklistStepItem>
     </div>
-  )
-}
+  );
+};

--- a/packages/reactv1/src/components/Checklists/HeroChecklist/StepChecklistItem.tsx
+++ b/packages/reactv1/src/components/Checklists/HeroChecklist/StepChecklistItem.tsx
@@ -48,7 +48,6 @@ export const StepChecklistItem: FC<StepItemProps> = ({
           value={data.complete}
           labelPosition="left"
           label={data.stepName ?? data.title}
-          aria-label={data.stepName ?? data.title}
           style={style}
           primaryColor={appearance?.theme?.colorPrimary ?? primaryColor}
           appearance={appearance}


### PR DESCRIPTION
This PR is meant to address several a11y issues on the Hero Checklist module. These are:

- Checkboxes now correctly set aria-checked on divs with `role="checkbox"`, so the check state is correctly reported. The `aria-checked` value only sets to true if `{value}` is explicitly to true; otherwise, this is set to false to catch undefined, nulls, etc.
- The Hero Checklist now has a parent role of `list`, as each checklist item has a child role of `listitem`.
- Labels are now correctly passed to checkboxes to associate the text together. This solution is a little kludgey (pass the value of label to the child checkbox component), and ideally an ID-driven `aria-labelledby` solution would be created, but I didn't want to change too much of the project.
- I noticed a slight typo on the `layoutId` property for `StepItemSelectedIndicator`; this has been updated.