### PR TITLE
Tooltip spotlight add zIndex from props

### DIFF
--- a/packages/react/src/components/Tooltip/index.tsx
+++ b/packages/react/src/components/Tooltip/index.tsx
@@ -180,6 +180,7 @@ export function Tooltip({
                 top: spotlightTop,
                 width: anchorRect.width,
               }}
+              zIndex={props.zIndex}
             />
           )}
           <Popover.Content asChild {...contentProps} ref={contentRef}>


### PR DESCRIPTION
Currently zIndex does not get passed to the Tooltip Spotlight resulting in scenarios where the Tooltip content is shown but the Spotlight is hidden. 