### PR TITLE
Modal fixes and top-level props

### DIFF
--- a/apps/smithy/src/stories/Collection/Collection.stories.tsx
+++ b/apps/smithy/src/stories/Collection/Collection.stories.tsx
@@ -36,3 +36,17 @@ export const MultipleComponents = {
     },
   ],
 };
+
+export const MultipleAnnouncements = {
+  decorators: [
+    () => (
+      <>
+        {/* Built in Dialogs Collection */}
+        <Collection collectionId="collection_49A28miL" />
+
+        {/* Storybook X & Y Announcements */}
+        <Collection collectionId="collection_DrlkZoXK" />
+      </>
+    ),
+  ],
+};

--- a/packages/js-api/src/core/flow.ts
+++ b/packages/js-api/src/core/flow.ts
@@ -46,6 +46,7 @@ export class Flow extends Fetchable {
    */
   public subtitle?: string
   /**
+   * @ignore Internal use only.
    * Props to pass through to the Flow Component in the React SDK.
    */
   public props?: Record<string, unknown> = {}

--- a/packages/js-api/src/core/flow.ts
+++ b/packages/js-api/src/core/flow.ts
@@ -46,6 +46,10 @@ export class Flow extends Fetchable {
    */
   public subtitle?: string
   /**
+   * Props to pass through to the Flow Component in the React SDK.
+   */
+  public props?: Record<string, unknown> = {}
+  /**
    * The metadata of the Flow.
    * @ignore
    */
@@ -108,6 +112,7 @@ export class Flow extends Fetchable {
     this.rawData = statefulFlow
     this.title = statefulFlow?.data?.title
     this.subtitle = statefulFlow?.data?.subtitle
+    this.props = statefulFlow?.data?.props ?? {}
 
     this.isCompleted = statefulFlow.$state.completed
     this.isStarted = statefulFlow.$state.started

--- a/packages/react/src/components/Flow/FlowProps.ts
+++ b/packages/react/src/components/Flow/FlowProps.ts
@@ -25,6 +25,10 @@ export interface FlowPropsWithoutChildren extends BoxPropsWithoutChildren {
    */
   forceMount?: boolean
   /**
+   * Register the Flow as a modal to prevent popup collisions (only one modal Flow will render at a time).
+   */
+  modal?: boolean
+  /**
    * Handler for when the Flow is completed.
    * If this function a promise that evaluates to `false`, the Flow will not be marked as completed.
    */
@@ -51,8 +55,7 @@ export interface FlowPropsWithoutChildren extends BoxPropsWithoutChildren {
   variables?: Record<string, unknown>
 
   /**
-   * Optional component type to wrap the child components in. Use the`as={Box}` component for inline placement or the `as={Dialog}` component for modal placement.
-   * If you want to wrap the Flow in a custom component (such as your own modal), you can pass the custom component here.
+   * Optional component to wrap the child components in, e.g. `as={Dialog}` will render the Flow in a modal Dialog. Defaults to `Box`.
    */
   as?: React.ElementType
 }

--- a/packages/react/src/components/Flow/index.tsx
+++ b/packages/react/src/components/Flow/index.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useContext, useEffect, useState } from 'react'
+import { FlowType } from '@frigade/js'
 
 import { Box } from '@/components/Box'
 
@@ -19,14 +20,13 @@ export type {
 export function Flow({
   as,
   children,
-  dismissible = false,
   flowId,
   onComplete,
   onDismiss,
   onPrimary,
   onSecondary,
   variables,
-  forceMount,
+
   ...props
 }: FlowProps) {
   const [hasProcessedRules, setHasProcessedRules] = useState(false)
@@ -34,6 +34,16 @@ export function Flow({
   const { flow } = useFlow(flowId, {
     variables,
   })
+
+  const {
+    dismissible = false,
+    forceMount = false,
+    modal = false,
+    ...mergedProps
+  } = {
+    ...(flow?.props ?? {}),
+    ...props,
+  }
 
   const { hasInitialized, registerComponent, unregisterComponent } = useContext(FrigadeContext)
 
@@ -49,7 +59,10 @@ export function Flow({
     onSecondary,
   })
 
-  const isModal = as && typeof as === 'function' && as.displayName === 'Dialog'
+  const isModal =
+    modal ||
+    (typeof as === 'function' && as?.displayName === 'Dialog') ||
+    [FlowType.ANNOUNCEMENT, FlowType.TOUR].includes(flow?.rawData?.flowType)
 
   const { isCurrentModal, removeModal } = useModal(flow, isModal)
 
@@ -96,7 +109,7 @@ export function Flow({
   const ContainerElement = as === null ? Fragment : as ?? Box
 
   const containerProps = {
-    ...props,
+    ...mergedProps,
     'data-flow-id': flow.id,
   }
 


### PR DESCRIPTION
### A few fixes and enhancements around modal Flow Components:
- Flow type now allows a `props` object at the top level, same as the existing `props` on FlowStep
- Flow Component now accepts a `modal` prop to manually flag a Flow embed as being modal
- Flow Component now automatically flags `FlowType.ANNOUNCEMENT` and `FlowType.TOUR` as modal

The main impetus for these changes was around enabling Collections, with a few minor QoL enhancements added in along the way.