### PR TITLE
Fix issues with invisible tooltip anchors

### DIFF
--- a/packages/react/src/components/Tooltip/index.tsx
+++ b/packages/react/src/components/Tooltip/index.tsx
@@ -27,6 +27,13 @@ const fadeIn = keyframes`
   }
 `
 
+function isVisible(elem: Element) {
+  if (!(elem instanceof HTMLElement)) {
+    return false
+  }
+  return !!(elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length)
+}
+
 export interface MergedRadixPopoverProps
   extends Pick<Popover.PopoverProps, 'defaultOpen' | 'modal' | 'onOpenChange' | 'open'>,
     Omit<
@@ -108,13 +115,21 @@ export function Tooltip({
   useEffect(() => {
     function checkElementForAnchor(element: Element) {
       if (element.matches(anchor)) {
-        return element
+        if (isVisible(element)) {
+          return element
+        } else {
+          return null
+        }
       }
 
       const anchorSelector = element.querySelectorAll(anchor)
 
       if (anchorSelector.length > 0) {
-        return anchorSelector[0]
+        if (isVisible(anchorSelector[0])) {
+          return anchorSelector[0]
+        } else {
+          return null
+        }
       }
 
       return null

--- a/packages/reactv1/src/components/Tooltips/Tooltips.tsx
+++ b/packages/reactv1/src/components/Tooltips/Tooltips.tsx
@@ -94,6 +94,12 @@ const HighlightContainer = styled(PositionWrapper)`
   width: ${HIGHLIGHT_RADIUS + 12}px;
   height: ${HIGHLIGHT_RADIUS + 12}px;
 `
+function isVisible(elem: Element) {
+  if (!(elem instanceof HTMLElement)) {
+    return false
+  }
+  return !!(elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length)
+}
 
 const Tooltips: FC<ToolTipPropsInternal> = ({
   steps = [],
@@ -167,7 +173,7 @@ const Tooltips: FC<ToolTipPropsInternal> = ({
     }
 
     const elem = document.querySelector(steps[selectedStep].selector)
-    if (!elem) {
+    if (!elem || !isVisible(elem)) {
       setLastBoundingRect(undefined)
       setElem(null)
       logErrorIfDebugMode(


### PR DESCRIPTION
#### As Is
Frigade Tour component's tooltip tries to anchor to `steps[index].selector` even if the DOM element has `display: none`.
This results in a tooltip rendered at the upper left corner of the screen.

#### To Be
If the anchor is invisible, treat it as if the anchor is missing.