### PR TITLE
fix: collission detection to respect flow.restart()

### DIFF
--- a/apps/smithy/src/stories/Announcement/Announcement.stories.tsx
+++ b/apps/smithy/src/stories/Announcement/Announcement.stories.tsx
@@ -42,3 +42,36 @@ export const TestReset = {
     },
   ],
 };
+
+export const ModalCollisions = {
+  decorators: [
+    (Story, { args }) => {
+      // const { frigade } = useFrigade();
+      const { flow: flowA } = useFlow("flow_gT6bpnCn");
+      const { flow: flowB } = useFlow("flow_FMjrv1vC");
+
+      return (
+        <div>
+          <Announcement flowId="flow_gT6bpnCn" />
+          <Announcement flowId="flow_FMjrv1vC" />
+          <button
+            onClick={async () => {
+              // const flow = await frigade.getFlow(args.flowId);
+              await flowA.restart();
+            }}
+          >
+            Reset flow A
+          </button>
+          <button
+            onClick={async () => {
+              // const flow = await frigade.getFlow(args.flowId);
+              await flowB.restart();
+            }}
+          >
+            Reset flow B
+          </button>
+        </div>
+      );
+    },
+  ],
+};

--- a/packages/react/src/components/Flow/index.tsx
+++ b/packages/react/src/components/Flow/index.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect } from 'react'
+import { Fragment } from 'react'
 import { FlowType } from '@frigade/js'
 
 import { Box } from '@/components/Box'
@@ -66,12 +66,6 @@ export function Flow({
 
   const { isCurrentModal, removeModal } = useModal(flow, isModal)
 
-  useEffect(() => {
-    if (!flow?.isVisible && isCurrentModal) {
-      removeModal()
-    }
-  }, [flow?.isVisible, isCurrentModal])
-
   // useEffect(() => {
   //   return () => {
   //     unregisterComponent(flowId)
@@ -101,6 +95,7 @@ export function Flow({
   // })
 
   if (!flow.isVisible && !shouldForceMount) {
+    removeModal()
     return null
   }
 

--- a/packages/react/src/components/Tour/index.tsx
+++ b/packages/react/src/components/Tour/index.tsx
@@ -38,12 +38,6 @@ export function Tour({ flowId, onComplete, variables, part, ...props }: TourProp
   const { isCurrentModal, removeModal } = useModal(flow)
 
   useEffect(() => {
-    if (!flow?.isVisible && isCurrentModal) {
-      removeModal()
-    }
-  }, [flow?.isVisible, isCurrentModal])
-
-  useEffect(() => {
     return () => {
       unregisterComponent(flowId)
     }
@@ -61,6 +55,10 @@ export function Tour({ flowId, onComplete, variables, part, ...props }: TourProp
 
   if (!hasInitialized || !hasProcessedRules) {
     return null
+  }
+
+  if (!flow?.isVisible) {
+    removeModal()
   }
 
   const step = flow.getCurrentStep()

--- a/packages/react/src/hooks/useModal.ts
+++ b/packages/react/src/hooks/useModal.ts
@@ -1,11 +1,10 @@
-import { useContext, useEffect, useState } from 'react'
+import { useContext, useEffect } from 'react'
 
 import { FrigadeContext } from '@/components/Provider'
 import type { Flow } from '@frigade/js'
 
 export function useModal(flow: Flow, isModal: boolean = true) {
   const { currentModal, modals, setModals } = useContext(FrigadeContext)
-  const [isCurrentModal, setIsCurrentModal] = useState(false)
 
   useEffect(() => {
     if (isModal && flow?.isVisible && flow && !modals.has(flow.id)) {
@@ -13,16 +12,7 @@ export function useModal(flow: Flow, isModal: boolean = true) {
     }
   }, [flow?.id, flow?.isVisible])
 
-  useEffect(() => {
-    const newIsCurrentModal = currentModal === flow?.id
-
-    if (isModal && flow?.id != null && newIsCurrentModal !== isCurrentModal) {
-      setIsCurrentModal(newIsCurrentModal)
-    }
-  }, [flow?.id, currentModal])
-
   function removeModal() {
-    if (!isModal) return
     if (modals.has(flow?.id)) {
       setModals((prevModals) => {
         const nextModals = new Set(prevModals)
@@ -34,7 +24,7 @@ export function useModal(flow: Flow, isModal: boolean = true) {
   }
 
   return {
-    isCurrentModal: isCurrentModal || !isModal,
+    isCurrentModal: !isModal ? true : currentModal === flow?.id,
     removeModal,
   }
 }

--- a/packages/react/src/hooks/useModal.ts
+++ b/packages/react/src/hooks/useModal.ts
@@ -14,12 +14,14 @@ export function useModal(flow: Flow, isModal: boolean = true) {
 
   function removeModal() {
     if (modals.has(flow?.id)) {
-      setModals((prevModals) => {
-        const nextModals = new Set(prevModals)
-        nextModals.delete(flow?.id)
+      setTimeout(() => {
+        setModals((prevModals) => {
+          const nextModals = new Set(prevModals)
+          nextModals.delete(flow?.id)
 
-        return nextModals
-      })
+          return nextModals
+        })
+      }, 0)
     }
   }
 


### PR DESCRIPTION
Fixes an issue where restarting a flow would prevent an announcement flow from opening up again due to colission detection.


https://github.com/user-attachments/assets/b3c1ca98-bc0d-474a-b097-c3246ddb5769

