### PR TITLE
fix: as={Dialog} modal collision detection

### DIFF
--- a/apps/smithy/src/stories/Form/Form.stories.tsx
+++ b/apps/smithy/src/stories/Form/Form.stories.tsx
@@ -32,11 +32,6 @@ export const Default = {
       customTest: CustomStep,
     },
     as: Dialog,
-    onOpenChange: (isOpen) => {
-      if (!isOpen) {
-        flow.skip();
-      }
-    },
     variables: {
       testVar: "hello world",
     },

--- a/packages/react/src/hooks/useModal.ts
+++ b/packages/react/src/hooks/useModal.ts
@@ -31,6 +31,6 @@ export function useModal(flow: Flow, isModal: boolean = true) {
   const currentModal = globalModalState.size > 0 ? globalModalState.values().next().value : null
 
   return {
-    isCurrentModal: !isModal ? true : currentModal === flow?.id,
+    isCurrentModal: !isModal ? true : currentModal === flow?.id || globalModalState.size == 0,
   }
 }


### PR DESCRIPTION
This appears to fix the issue where a `<Form as={Dialog} />` doesn't spawn in some cases (it gets blocked by useModal because `flow` is undefined).

The real fix is to figure out why the hook doesn't run when `flow` becomes defined, but I wasn't able to figure this out just yet. This fix, however, does seem to work for all use cases in storybook (see attached demo).


https://github.com/user-attachments/assets/9bcfea53-c45d-4982-937e-730df605381d

