### PR TITLE
fix: remove modals on url change

### DIFF
--- a/apps/smithy/src/stories/hooks/useFlow.stories.tsx
+++ b/apps/smithy/src/stories/hooks/useFlow.stories.tsx
@@ -16,7 +16,6 @@ export function Default() {
   }
 
   console.log("isLoading:", isLoading);
-  flow.rawData.flowType;
 
   return (
     <div>

--- a/packages/react/src/hooks/useModal.ts
+++ b/packages/react/src/hooks/useModal.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect } from 'react'
 import type { Flow } from '@frigade/js'
 
-export let globalModalState: Set<string> = new Set()
+export const globalModalState: Set<string> = new Set()
 
 export function useModal(flow: Flow, isModal: boolean = true) {
   const removeModal = useCallback(() => {
@@ -21,6 +21,23 @@ export function useModal(flow: Flow, isModal: boolean = true) {
       removeModal()
     }
   }, [])
+
+  useEffect(() => {
+    registerModal()
+
+    const handleRouteChange = () => {
+      removeModal()
+    }
+
+    window.addEventListener('popstate', handleRouteChange)
+    window.addEventListener('beforeunload', handleRouteChange)
+
+    return () => {
+      removeModal()
+      window.removeEventListener('popstate', handleRouteChange)
+      window.removeEventListener('beforeunload', handleRouteChange)
+    }
+  }, [registerModal, removeModal])
 
   if (!flow?.isVisible) {
     removeModal()


### PR DESCRIPTION
As it turns out, the unmount function is not called in some cases when a route is changed. Therefore, we want to make sure we remove the current modal if the route changes. This fix also ensures that if the component reemerges on a different route, it will line up in the modal queue again.