### PR TITLE
fix: cancel pending requests on redirect

### DIFF
--- a/apps/smithy/src/stories/Announcement/Announcement.stories.tsx
+++ b/apps/smithy/src/stories/Announcement/Announcement.stories.tsx
@@ -8,7 +8,7 @@ export default {
 export const Default = {
   args: {
     dismissible: true,
-    flowId: "flow_cvWFczn1RMHp9ZcK",
+    flowId: "flow_8Ybz7lMK",
     modal: true,
     onDismiss: () => console.log("Dismissed"),
   },
@@ -17,7 +17,7 @@ export const Default = {
 export const TestReset = {
   args: {
     dismissible: true,
-    flowId: "flow_cvWFczn1RMHp9ZcK",
+    flowId: "flow_8Ybz7lMK",
   },
   decorators: [
     (Story, { args }) => {

--- a/packages/js-api/src/core/frigade.ts
+++ b/packages/js-api/src/core/frigade.ts
@@ -281,6 +281,13 @@ export class Frigade extends Fetchable {
     return collection
   }
 
+  /**
+   * @ignore
+   */
+  public getCollectionsSync(): CollectionsList | undefined {
+    return this.getGlobalState().collections.getCollections()
+  }
+
   public async getCollections(): Promise<CollectionsList | undefined> {
     await this.initIfNeeded()
 
@@ -418,15 +425,18 @@ export class Frigade extends Fetchable {
 
         const flowStateRaw: FlowStates = overrideFlowStateRaw
           ? overrideFlowStateRaw
-          : await this.fetch('/v1/public/flowStates', {
-              method: 'POST',
-              body: JSON.stringify({
-                userId: this.getGlobalState().config.userId,
-                groupId: this.getGlobalState().config.groupId,
-                context: getContext(this.getGlobalState()),
-              } as FlowStateDTO),
-              cancelPendingRequests,
-            })
+          : await this.fetch(
+              '/v1/public/flowStates',
+              {
+                method: 'POST',
+                body: JSON.stringify({
+                  userId: this.getGlobalState().config.userId,
+                  groupId: this.getGlobalState().config.groupId,
+                  context: getContext(this.getGlobalState()),
+                } as FlowStateDTO),
+              },
+              cancelPendingRequests
+            )
 
         const collectionsData: CollectionsList = new Map()
 

--- a/packages/js-api/src/core/frigade.ts
+++ b/packages/js-api/src/core/frigade.ts
@@ -66,7 +66,7 @@ export class Frigade extends Fetchable {
             }
 
             this.getGlobalState().currentUrl = event.destination.url
-            this.refreshStateFromAPI()
+            this.refreshStateFromAPI(true)
           } catch (e) {}
         })
       }
@@ -365,7 +365,7 @@ export class Frigade extends Fetchable {
   /**
    * @ignore
    */
-  private async refreshStateFromAPI(): Promise<void> {
+  private async refreshStateFromAPI(cancelPendingRequests: boolean = false): Promise<void> {
     const globalStateKey = getGlobalStateKey(this.config)
 
     if (!frigadeGlobalState[globalStateKey]) {
@@ -409,7 +409,8 @@ export class Frigade extends Fetchable {
       }
 
       frigadeGlobalState[globalStateKey].refreshStateFromAPI = async (
-        overrideFlowStateRaw?: FlowStates
+        overrideFlowStateRaw?: FlowStates,
+        cancelPendingRequests?: boolean
       ) => {
         if (this.config.__readOnly) {
           return
@@ -424,6 +425,7 @@ export class Frigade extends Fetchable {
                 groupId: this.getGlobalState().config.groupId,
                 context: getContext(this.getGlobalState()),
               } as FlowStateDTO),
+              cancelPendingRequests,
             })
 
         const collectionsData: CollectionsList = new Map()
@@ -474,7 +476,7 @@ export class Frigade extends Fetchable {
       }
     }
 
-    await frigadeGlobalState[globalStateKey].refreshStateFromAPI()
+    await frigadeGlobalState[globalStateKey].refreshStateFromAPI(undefined, cancelPendingRequests)
   }
 
   /**

--- a/packages/js-api/src/shared/fetchable.ts
+++ b/packages/js-api/src/shared/fetchable.ts
@@ -25,16 +25,24 @@ export class Fetchable {
   /**
    * @ignore
    */
-  public async fetch(path: string, options?: Record<any, any>) {
+  public async fetch(
+    path: string,
+    options?: Record<any, any>,
+    cancelPendingRequests: boolean = false
+  ) {
     if (this.config.__readOnly) {
       return getEmptyResponse()
     }
 
-    return gracefulFetch(this.getAPIUrl(path), {
-      keepalive: true,
-      ...(options ?? {}),
-      ...getHeaders(this.config),
-    })
+    return gracefulFetch(
+      this.getAPIUrl(path),
+      {
+        keepalive: true,
+        ...(options ?? {}),
+        ...getHeaders(this.config),
+      },
+      cancelPendingRequests
+    )
   }
 
   private getAPIUrl(path: string) {

--- a/packages/js-api/src/shared/state.ts
+++ b/packages/js-api/src/shared/state.ts
@@ -3,7 +3,10 @@ import { Flow } from '../core/flow'
 import type { Collections } from '../core/collections'
 
 export interface FrigadeGlobalState {
-  refreshStateFromAPI: (overrideFlowStatesRaw?: FlowStates) => Promise<void>
+  refreshStateFromAPI: (
+    overrideFlowStatesRaw?: FlowStates,
+    cancelPendingRequests?: boolean
+  ) => Promise<void>
   flowStates: Record<string, StatefulFlow>
   collections: Collections
   registeredCollectionIds: Set<string>

--- a/packages/js-api/src/shared/utils.ts
+++ b/packages/js-api/src/shared/utils.ts
@@ -152,12 +152,15 @@ export async function gracefulFetch(
         )
       }
 
-      response = await pendingResponse
+      response = pendingResponse
       // check if call queue still has this request
+      // it could be removed if a newer request has been made
       if (!callQueue.hasCall(lastCallDataKey)) {
-        // if not, cancel the request
+        // if not, abort the request
+        response?.abort()
         return getEmptyResponse()
       }
+      response = await pendingResponse
     } catch (error) {
       return getEmptyResponse(error)
     }

--- a/packages/js-api/src/shared/utils.ts
+++ b/packages/js-api/src/shared/utils.ts
@@ -16,6 +16,7 @@ const GUEST_KEY = 'frigade-guest-key'
 export const GUEST_PREFIX = 'guest_'
 const GET_CACHE_PREFIX = 'get-cache-'
 const LOCAL_STORAGE_PREFIX = 'fr-js-'
+const REDUNDANT_CALL_MESSAGE = 'Redundant call to Frigade API removed'
 
 export function cloneFlow(flow: Flow): Flow {
   const newFlow = new Flow({
@@ -106,7 +107,7 @@ class CallQueue {
 
   public cancelAllPendingRequests() {
     // abort all requests
-    this.controller.abort('Redundant call to Frigade API removed')
+    this.controller.abort(REDUNDANT_CALL_MESSAGE)
     this.queue = []
     this.controller = new AbortController()
   }
@@ -201,7 +202,11 @@ export async function gracefulFetch(
 
 export function getEmptyResponse(error?: any) {
   if (error) {
-    console.warn('Call to Frigade failed:', error)
+    if (error === REDUNDANT_CALL_MESSAGE) {
+      console.debug(error)
+    } else {
+      console.warn('Call to Frigade failed:', error)
+    }
   }
 
   // Create empty response that contains the .json method and returns an empty object

--- a/packages/react/src/components/Provider/DefaultCollection.tsx
+++ b/packages/react/src/components/Provider/DefaultCollection.tsx
@@ -1,21 +1,12 @@
-import { useEffect, useState } from 'react'
-
 import { Collection } from '@/components/Collection'
-import { useFrigade } from '@/hooks/useFrigade'
+import { useCollections } from '@/hooks/useCollections'
 
 export function DefaultCollection() {
-  const [collectionId, setCollectionId] = useState<string>()
-  const { frigade } = useFrigade()
+  const { collections } = useCollections()
 
-  useEffect(() => {
-    frigade.getCollections().then((collections) => {
-      collections?.forEach((c, id) => {
-        if (c.collectionType === 'DEFAULT') {
-          setCollectionId(id)
-        }
-      })
-    })
-  }, [])
+  const collectionId = Array.from(collections?.entries() ?? []).find(
+    (entry) => entry[1].collectionType === 'DEFAULT'
+  )?.[0]
 
   if (collectionId == null) {
     return null

--- a/packages/react/src/hooks/useCollections.ts
+++ b/packages/react/src/hooks/useCollections.ts
@@ -1,0 +1,57 @@
+import { useCallback, useContext, useState, useSyncExternalStore } from 'react'
+
+import { FrigadeContext } from '@/components/Provider'
+
+import { CollectionsList } from '@frigade/js'
+
+export function useCollections() {
+  const { frigade } = useContext(FrigadeContext)
+  const [, setForceRender] = useState<boolean>(false)
+
+  let debounceTimeout: ReturnType<typeof setTimeout>
+
+  const subscribe = useCallback((cb: () => void) => {
+    // TODO: Why is there a noticeable delay when this is commented out?
+    frigade?.getCollections().then(() => {
+      cb()
+    })
+
+    const handler = () => {
+      clearTimeout(debounceTimeout)
+
+      /*
+       * NOTE: Since React doesn't re-render on deep object diffs,
+       * we need to gently prod it here by creating a state update.
+       */
+      debounceTimeout = setTimeout(() => {
+        setForceRender((forceRender) => !forceRender)
+
+        cb()
+      }, 0)
+    }
+
+    frigade?.onStateChange(handler)
+
+    return () => {
+      frigade?.removeStateChangeHandler(handler)
+    }
+  }, [])
+
+  const getSnapshot = () => {
+    let result = undefined
+
+    try {
+      result = frigade?.getCollectionsSync()
+    } catch (noGlobalStateYet) {
+      // no-op
+    }
+
+    return result
+  }
+
+  const collections: CollectionsList = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+
+  return {
+    collections,
+  }
+}


### PR DESCRIPTION
Cancels any pending requests if a URL change happens.

**Testing done**:

- Tested manually via storybook that modal flickers caused by non cancelling pending requests are correctly resolved (see demo).
- Tested existing storybook stories


https://github.com/user-attachments/assets/ea7c40fd-b63b-4b6f-a899-a992b855b80b

