### PR TITLE
Flow props standardization

### DIFF
--- a/apps/smithy/src/stories/Announcement/Announcement.stories.tsx
+++ b/apps/smithy/src/stories/Announcement/Announcement.stories.tsx
@@ -8,7 +8,7 @@ export default {
 export const Default = {
   args: {
     dismissible: true,
-    flowId: "flow_8Ybz7lMK",
+    flowId: "flow_vLivpwoH",
     modal: true,
     onDismiss: () => console.log("Dismissed"),
   },

--- a/apps/smithy/src/stories/Form/Form.stories.tsx
+++ b/apps/smithy/src/stories/Form/Form.stories.tsx
@@ -32,7 +32,7 @@ export const Default = {
     fieldTypes: {
       customTest: CustomStep,
     },
-    as: Dialog,
+    // as: Dialog,
     variables: {
       testVar: "hello world",
     },

--- a/packages/react/src/components/Announcement/index.tsx
+++ b/packages/react/src/components/Announcement/index.tsx
@@ -19,114 +19,83 @@ export interface AnnouncementProps extends FlowPropsWithoutChildren, DialogProps
   defaultOpen?: boolean
 }
 
-const flowPropNames = [
-  'dismissible',
-  'flowId',
-  'forceMount',
-  'onComplete',
-  'onDismiss',
-  'onPrimary',
-  'onSecondary',
-  'variables',
-]
-
 export function Announcement({ flowId, part, ...props }: AnnouncementProps) {
-  const flowProps = Object.fromEntries(
-    Object.entries(props).filter(([k]) => flowPropNames.some((name) => k === name))
-  )
-  const dialogProps = Object.fromEntries(
-    Object.entries(props).filter(([k]) => flowPropNames.indexOf(k) === -1)
-  )
-
   return (
-    <Flow as={null} flowId={flowId} {...flowProps}>
+    <Flow
+      as={Dialog}
+      display="flex"
+      flexDirection="column"
+      flowId={flowId}
+      gap={5}
+      part={['announcement', part]}
+      textAlign="center"
+      {...props}
+    >
       {({
         flow,
         handleDismiss,
         handlePrimary,
         handleSecondary,
-        parentProps: { containerProps, dismissible },
+        parentProps: { dismissible },
         step,
       }) => {
-        const stepProps = step.props ?? {}
-
         const primaryButtonTitle = step.primaryButton?.title ?? step.primaryButtonTitle
         const secondaryButtonTitle = step.secondaryButton?.title ?? step.secondaryButtonTitle
 
         const disabled = step.$state.blocked
 
-        const { videoProps } = getVideoProps(stepProps)
+        const { videoProps } = getVideoProps(step.props ?? {})
 
         return (
-          <Dialog
-            part={['announcement', part]}
-            textAlign="center"
-            {...containerProps}
-            {...dialogProps}
-            onEscapeKeyDown={(e) => {
-              if (props.dismissible === false) {
-                e.preventDefault()
-                return
-              }
-              if (typeof props.onEscapeKeyDown === 'function') {
-                props.onEscapeKeyDown(e)
-              }
-
-              if (!e.defaultPrevented) {
-                handleDismiss(e)
-              }
-            }}
-          >
-            <Flex.Column gap={5} part="announcement-step" {...stepProps}>
-              {dismissible && <Dialog.Dismiss onClick={handleDismiss} />}
-              <Flex.Column gap={1} part="announcement-header">
-                <Dialog.Title>{step.title}</Dialog.Title>
-                <Dialog.Subtitle>{step.subtitle}</Dialog.Subtitle>
-              </Flex.Column>
-
-              <Dialog.Media
-                aspectRatio="1.5"
-                objectFit="cover"
-                overflowClipMargin="unset"
-                src={step.videoUri ?? step.imageUri}
-                transform="translate3d(0, 0, 1px)"
-                type={step.videoUri ? 'video' : 'image'}
-                width="100%"
-                {...videoProps}
-              />
-
-              <Dialog.ProgressDots
-                current={flow.getCurrentStepIndex()}
-                total={flow.getNumberOfAvailableSteps()}
-              />
-
-              <Flex.Row
-                css={{
-                  '& > button': {
-                    flexBasis: '50%',
-                    flexGrow: 1,
-                  },
-                }}
-                gap={3}
-                part="announcement-footer"
-              >
-                {secondaryButtonTitle && (
-                  <Dialog.Secondary
-                    disabled={disabled}
-                    onClick={handleSecondary}
-                    title={secondaryButtonTitle}
-                  />
-                )}
-                {primaryButtonTitle && (
-                  <Dialog.Primary
-                    disabled={disabled}
-                    onClick={handlePrimary}
-                    title={primaryButtonTitle}
-                  />
-                )}
-              </Flex.Row>
+          <>
+            {dismissible && <Dialog.Dismiss onClick={handleDismiss} />}
+            <Flex.Column gap={1} part="announcement-header">
+              <Dialog.Title>{step.title}</Dialog.Title>
+              <Dialog.Subtitle>{step.subtitle}</Dialog.Subtitle>
             </Flex.Column>
-          </Dialog>
+
+            <Dialog.Media
+              aspectRatio="1.5"
+              objectFit="cover"
+              overflowClipMargin="unset"
+              src={step.videoUri ?? step.imageUri}
+              transform="translate3d(0, 0, 1px)"
+              type={step.videoUri ? 'video' : 'image'}
+              width="100%"
+              {...videoProps}
+            />
+
+            <Dialog.ProgressDots
+              current={flow.getCurrentStepIndex()}
+              total={flow.getNumberOfAvailableSteps()}
+            />
+
+            <Flex.Row
+              css={{
+                '& > button': {
+                  flexBasis: '50%',
+                  flexGrow: 1,
+                },
+              }}
+              gap={3}
+              part="announcement-footer"
+            >
+              {secondaryButtonTitle && (
+                <Dialog.Secondary
+                  disabled={disabled}
+                  onClick={handleSecondary}
+                  title={secondaryButtonTitle}
+                />
+              )}
+              {primaryButtonTitle && (
+                <Dialog.Primary
+                  disabled={disabled}
+                  onClick={handlePrimary}
+                  title={primaryButtonTitle}
+                />
+              )}
+            </Flex.Row>
+          </>
         )
       }}
     </Flow>

--- a/packages/react/src/components/Banner/index.tsx
+++ b/packages/react/src/components/Banner/index.tsx
@@ -7,35 +7,28 @@ export interface BannerProps extends FlowPropsWithoutChildren {}
 
 export function Banner({ dismissible, flowId, part, ...props }: BannerProps) {
   return (
-    <Flow as={null} flowId={flowId} {...props}>
-      {({
-        handleDismiss,
-        handlePrimary,
-        handleSecondary,
-        parentProps: { containerProps },
-        step,
-      }) => {
-        const stepProps = step.props ?? {}
-
+    <Flow
+      alignItems="center"
+      aria-label="Banner"
+      as={Card}
+      borderWidth="md"
+      display="flex"
+      flexDirection="row"
+      flowId={flowId}
+      gap={3}
+      justifyContent="flex-start"
+      part={['banner', part]}
+      role="complementary"
+      {...props}
+    >
+      {({ handleDismiss, handlePrimary, handleSecondary, step }) => {
         const primaryButtonTitle = step.primaryButton?.title ?? step.primaryButtonTitle
         const secondaryButtonTitle = step.secondaryButton?.title ?? step.secondaryButtonTitle
 
         const disabled = step.$state.blocked
 
         return (
-          <Card
-            alignItems="center"
-            aria-label="Banner"
-            borderWidth="md"
-            display="flex"
-            flexDirection="row"
-            gap={3}
-            justifyContent="flex-start"
-            part={['banner', part]}
-            role="complementary"
-            {...containerProps}
-            {...stepProps}
-          >
+          <>
             {step.imageUri && (
               <Box
                 as="img"
@@ -57,7 +50,7 @@ export function Banner({ dismissible, flowId, part, ...props }: BannerProps) {
             />
             <Card.Primary disabled={disabled} title={primaryButtonTitle} onClick={handlePrimary} />
             {dismissible && <Card.Dismiss onClick={handleDismiss} />}
-          </Card>
+          </>
         )
       }}
     </Flow>

--- a/packages/react/src/components/Banner/index.tsx
+++ b/packages/react/src/components/Banner/index.tsx
@@ -5,7 +5,7 @@ import { Box } from '@/components/Box'
 
 export interface BannerProps extends FlowPropsWithoutChildren {}
 
-export function Banner({ dismissible, flowId, part, ...props }: BannerProps) {
+export function Banner({ flowId, part, ...props }: BannerProps) {
   return (
     <Flow
       alignItems="center"
@@ -21,7 +21,7 @@ export function Banner({ dismissible, flowId, part, ...props }: BannerProps) {
       role="complementary"
       {...props}
     >
-      {({ handleDismiss, handlePrimary, handleSecondary, step }) => {
+      {({ handleDismiss, handlePrimary, handleSecondary, parentProps: { dismissible }, step }) => {
         const primaryButtonTitle = step.primaryButton?.title ?? step.primaryButtonTitle
         const secondaryButtonTitle = step.secondaryButton?.title ?? step.secondaryButtonTitle
 

--- a/packages/react/src/components/Card/index.tsx
+++ b/packages/react/src/components/Card/index.tsx
@@ -86,6 +86,14 @@ Card.Footer = ({ children, part, ...props }: BoxProps) => {
 }
 
 Card.Header = ({ dismissible, handleDismiss, part, subtitle, title, ...props }) => {
+  if (
+    !dismissible &&
+    (title == null || title?.length === 0) &&
+    (subtitle == null || subtitle?.length === 0)
+  ) {
+    return null
+  }
+
   return (
     <Flex.Row
       alignItems="flex-start"

--- a/packages/react/src/components/Checklist/Collapsible.tsx
+++ b/packages/react/src/components/Checklist/Collapsible.tsx
@@ -141,7 +141,6 @@ function StepWrapper({ flow, step, ...props }: FlowChildrenProps) {
 }
 
 export function Collapsible({
-  dismissible,
   flowId,
   onPrimary,
   onSecondary,
@@ -178,6 +177,9 @@ export function Collapsible({
 
           const currentSteps = flow.getNumberOfCompletedSteps()
           const availableSteps = flow.getNumberOfAvailableSteps()
+
+          // Note: Ignore merged props from step here, Checklist steps don't control flow dismissibility
+          const dismissible = props.dismissible || !!flow?.props?.dismissible
 
           return (
             <>

--- a/packages/react/src/components/Flow/index.tsx
+++ b/packages/react/src/components/Flow/index.tsx
@@ -35,6 +35,10 @@ export function Flow({
     variables,
   })
 
+  const step = flow?.getCurrentStep()
+
+  const stepProps = step?.props ?? {}
+
   const {
     dismissible = false,
     forceMount = false,
@@ -42,11 +46,10 @@ export function Flow({
   } = {
     ...props,
     ...(flow?.props ?? {}),
+    ...(flow?.rawData?.flowType === FlowType.CHECKLIST ? {} : stepProps),
   }
 
   // const { hasInitialized, registerComponent, unregisterComponent } = useContext(FrigadeContext)
-
-  const step = flow?.getCurrentStep()
 
   const { handleDismiss } = useFlowHandlers(flow, {
     onComplete,

--- a/packages/react/src/components/Flow/index.tsx
+++ b/packages/react/src/components/Flow/index.tsx
@@ -9,6 +9,7 @@ import { useStepHandlers } from '@/hooks/useStepHandlers'
 import { useCheckForModalCollision } from '@/hooks/useModal'
 
 import type { FlowProps } from '@/components/Flow/FlowProps'
+import { getVideoProps } from '@/components/Media/videoProps'
 // import { FrigadeContext } from '@/components/Provider'
 
 export type {
@@ -37,7 +38,10 @@ export function Flow({
 
   const step = flow?.getCurrentStep()
 
-  const stepProps = step?.props ?? {}
+  const initialStepProps = step?.props ?? {}
+
+  // Discard video props when merging step props onto top-level container
+  const { otherProps: stepProps } = getVideoProps(initialStepProps)
 
   const {
     dismissible = false,

--- a/packages/react/src/components/Form/FormStep.tsx
+++ b/packages/react/src/components/Form/FormStep.tsx
@@ -110,8 +110,6 @@ export function FormStep({
 
   const { control, handleSubmit } = formContext
 
-  const stepProps = step.props ?? {}
-
   function onPrimarySubmit(properties: PropertyPayload, e: SyntheticEvent<object, unknown>) {
     setIsSubmitting(true)
     handlePrimary(e, properties, __readOnly === true).then(() => setIsSubmitting(false))
@@ -141,7 +139,7 @@ export function FormStep({
   }, [step])
 
   return (
-    <Flex.Column gap={5} part="form-step" {...stepProps}>
+    <>
       <Card.Header
         dismissible={dismissible}
         handleDismiss={handleDismiss}
@@ -168,6 +166,6 @@ export function FormStep({
           loading={isSubmitting}
         />
       </Flex.Row>
-    </Flex.Column>
+    </>
   )
 }

--- a/packages/react/src/components/Form/index.tsx
+++ b/packages/react/src/components/Form/index.tsx
@@ -1,6 +1,7 @@
 import { FlowStep } from '@frigade/js'
 import type { ControllerFieldState, Message, UseFormReturn, ValidationRule } from 'react-hook-form'
 
+import { Card } from '@/components/Card'
 import { Flow, type FlowPropsWithoutChildren } from '@/components/Flow'
 
 import { FormStep } from './FormStep'
@@ -108,7 +109,7 @@ export function Form({ fieldTypes = {}, flowId, part, ...props }: FormProps) {
   const mergedFieldTypes = Object.assign({}, defaultFieldTypes, fieldTypes)
 
   return (
-    <Flow flowId={flowId} part={['form', part]} {...props}>
+    <Flow as={Card} flowId={flowId} part={['form', part]} {...props}>
       {(childProps) => <FormStep fieldTypes={mergedFieldTypes} {...childProps} />}
     </Flow>
   )


### PR DESCRIPTION
- Standardize how Flow-aware components handle prop overrides from YAML
- Same thing for the `dismissible` prop (except in Carousel, which for some reason doesn't have a dismiss button)
- Remove unneeded instances of the `<Flow as={null} ... >` pattern (I used it originally to get access to props from YAML, but those are now correctly merged and passed through to the top-level container that Flow renders)

Potential breaking change:
- Announcement no longer has an extraneous step wrapper. If CSS was targeted to it, that CSS will no longer apply.