### PR TITLE
feat: do not start a tour/hint flow until the anchor is visible

### DIFF
--- a/apps/smithy/src/stories/Tour/Tour.stories.tsx
+++ b/apps/smithy/src/stories/Tour/Tour.stories.tsx
@@ -109,6 +109,46 @@ export const Default = {
   ],
 };
 
+export const AnchorNotFound = {
+  args: {
+    autoScroll: true,
+    flowId: "flow_U63A5pndRrvCwxNs",
+    defaultOpen: true,
+  },
+  decorators: [
+    (_: StoryFn, options: StoryContext) => {
+      return (
+        <>
+          <Box
+            style={{
+              alignItems: "center",
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "center",
+              height: "calc(100vh - 32px)",
+            }}
+          >
+            <Box
+              borderRadius="10px"
+              id="tooltip-storybook-nonexistent"
+              p={4}
+              style={{ background: "red", width: "200px" }}
+            >
+              <Button.Primary
+                title="Non-existent Anchor"
+                onClick={() => {
+                  // no-op
+                }}
+              />
+            </Box>
+            <Tour {...(options.args as TourProps)} />
+          </Box>
+        </>
+      );
+    },
+  ],
+};
+
 export const WithScrollContainer = {
   args: {
     autoScroll: true,

--- a/apps/smithy/src/stories/Tour/TourInteractionTests.stories.tsx
+++ b/apps/smithy/src/stories/Tour/TourInteractionTests.stories.tsx
@@ -16,7 +16,7 @@ const StoryMeta: Meta<typeof Tour> = {
 
 export default StoryMeta;
 
-export const InteractionTests: TourStory = {
+export const AnchorFoundInteractionTests: TourStory = {
   args: {
     flowId: "flow_U63A5pndRrvCwxNs",
   },
@@ -24,6 +24,7 @@ export const InteractionTests: TourStory = {
   decorators: [
     (Story, { args }) => {
       const { flow } = useFlow(args.flowId);
+      args.flow = flow;
 
       const lateAnchorRef = useRef(null);
 
@@ -52,7 +53,7 @@ export const InteractionTests: TourStory = {
           <button
             id="reset-flow"
             onClick={() => {
-              flow.restart();
+              flow?.restart();
             }}
             style={{ marginTop: "36px" }}
           >
@@ -103,11 +104,21 @@ export const InteractionTests: TourStory = {
     },
   ],
 
-  play: async ({ step }) => {
+  play: async ({ step, args }) => {
+    console.log("args", args);
+
     await step("Test paginating through the Tour", async () => {
       const canvas = within(document.body);
+      await waitFor(() => {
+        expect(args.flow).toBeDefined();
+      });
+
       let TourElement = await canvas.findByRole("dialog");
       let Tour = within(TourElement);
+
+      await waitFor(() => {
+        expect(args.flow?.isStarted).toBe(true);
+      });
 
       await userEvent.click(Tour.getByRole("button", { name: "Let's go!" }));
       await sleep(100);
@@ -120,7 +131,6 @@ export const InteractionTests: TourStory = {
       );
 
       await sleep(100);
-
       TourElement = await canvas.findByRole("dialog");
       Tour = within(TourElement);
 
@@ -137,6 +147,49 @@ export const InteractionTests: TourStory = {
       await userEvent.click(canvas.getByText("Reset Flow"));
 
       await sleep(1000);
+    });
+  },
+};
+
+export const AnchorNotFoundInteractionTests: TourStory = {
+  args: {
+    flowId: "flow_U63A5pndRrvCwxNs",
+  },
+
+  decorators: [
+    (Story, { args }) => {
+      const { flow } = useFlow(args.flowId);
+      args.flow = flow;
+
+      return (
+        <>
+          <Story {...args} />
+          <button
+            id="reset-flow"
+            onClick={() => {
+              flow?.restart();
+            }}
+            style={{ marginTop: "36px" }}
+          >
+            Reset Flow
+          </button>
+          <Box id="anchor-not-found" />
+        </>
+      );
+    },
+  ],
+
+  play: async ({ step, args }) => {
+    console.log("args", args);
+
+    await step("Test Anchor Not Found", async () => {
+      // Wait for flow to be defined
+      await waitFor(() => {
+        expect(args.flow).toBeDefined();
+      });
+
+      // Verify the flow is started
+      expect(args.flow?.isStarted).toBe(false);
     });
   },
 };

--- a/packages/react/src/components/Flow/FlowProps.ts
+++ b/packages/react/src/components/Flow/FlowProps.ts
@@ -73,6 +73,13 @@ export interface FlowProps extends FlowPropsWithoutChildren {
    * Flow accepts a render function as its only child, whose props are described in FlowChildrenProps
    */
   children?: (props: FlowChildrenProps) => ReactNode
+  /**
+   * Whether to automatically mark the Flow started (i.e. in progress) when the Flow is eligible to be shown.
+   * You will need to call `flow.start()` or `step.start()` from the parent component if you set this to `false`. Most components should not need to override this behavior.
+   *
+   * Defaults to `true`.
+   */
+  autoStart?: boolean
 }
 
 type ParentProps = {

--- a/packages/react/src/components/Flow/FlowProps.ts
+++ b/packages/react/src/components/Flow/FlowProps.ts
@@ -11,6 +11,26 @@ export interface BoxPropsWithoutChildren extends Omit<BoxProps, 'children'> {}
 
 export interface FlowPropsWithoutChildren extends BoxPropsWithoutChildren {
   /**
+   * Whether to automatically mark the Flow started (i.e. in progress) when the Flow is eligible to be shown.
+   * You will need to call `flow.start()` or `step.start()` from the parent component if you set this to `false`. Most components should not need to override this behavior.
+   *
+   * Defaults to `true`.
+   */
+  autoStart?: boolean
+  /**
+   * Optional component to wrap the child components in, e.g. `as={Dialog}` will render the Flow in a modal Dialog. Defaults to `Box`.
+   */
+  as?: React.ElementType
+  /**
+   * Emotion CSS prop to apply to the component. See [Theming documentation](https://docs.frigade.com/v2/sdk/styling/css-overrides) for more information.
+   *
+   * Example usage:
+   * ```
+   * <Frigade.Checklist css={{ backgroundColor: "pink", ".fr-button-primary": { backgroundColor: "fuchsia" } }} />
+   * ```
+   */
+  css?: React.Attributes['css']
+  /**
    * Whether the Flow is dismissible or not
    *
    */
@@ -51,21 +71,6 @@ export interface FlowPropsWithoutChildren extends BoxPropsWithoutChildren {
    * For instance, you can use `title: Hello, ${name}!` in the Flow configuration and pass `variables={{name: 'John'}}` to customize the copy.
    */
   variables?: Record<string, unknown>
-
-  /**
-   * Optional component to wrap the child components in, e.g. `as={Dialog}` will render the Flow in a modal Dialog. Defaults to `Box`.
-   */
-  as?: React.ElementType
-
-  /**
-   * Emotion CSS prop to apply to the component. See [Theming documentation](https://docs.frigade.com/v2/sdk/styling/css-overrides) for more information.
-   *
-   * Example usage:
-   * ```
-   * <Frigade.Checklist css={{ backgroundColor: "pink", ".fr-button-primary": { backgroundColor: "fuchsia" } }} />
-   * ```
-   */
-  css?: React.Attributes['css']
 }
 
 export interface FlowProps extends FlowPropsWithoutChildren {
@@ -73,13 +78,6 @@ export interface FlowProps extends FlowPropsWithoutChildren {
    * Flow accepts a render function as its only child, whose props are described in FlowChildrenProps
    */
   children?: (props: FlowChildrenProps) => ReactNode
-  /**
-   * Whether to automatically mark the Flow started (i.e. in progress) when the Flow is eligible to be shown.
-   * You will need to call `flow.start()` or `step.start()` from the parent component if you set this to `false`. Most components should not need to override this behavior.
-   *
-   * Defaults to `true`.
-   */
-  autoStart?: boolean
 }
 
 type ParentProps = {

--- a/packages/react/src/components/Flow/index.tsx
+++ b/packages/react/src/components/Flow/index.tsx
@@ -24,6 +24,7 @@ function isDialog(component) {
 
 export function Flow({
   as,
+  autoStart = true,
   children,
   flowId,
   onComplete,
@@ -31,7 +32,6 @@ export function Flow({
   onPrimary,
   onSecondary,
   variables,
-  autoStart = true,
   ...props
 }: FlowProps) {
   // const [hasProcessedRules, setHasProcessedRules] = useState(false)

--- a/packages/react/src/components/Flow/index.tsx
+++ b/packages/react/src/components/Flow/index.tsx
@@ -31,7 +31,7 @@ export function Flow({
   onPrimary,
   onSecondary,
   variables,
-
+  autoStart = true,
   ...props
 }: FlowProps) {
   // const [hasProcessedRules, setHasProcessedRules] = useState(false)
@@ -123,7 +123,7 @@ export function Flow({
   //   return null
   // }
 
-  if (shouldForceMount || (!flow.isCompleted && !flow.isSkipped)) {
+  if (shouldForceMount || (!flow.isCompleted && !flow.isSkipped && autoStart)) {
     step?.start()
   }
 

--- a/packages/react/src/components/Hint/index.tsx
+++ b/packages/react/src/components/Hint/index.tsx
@@ -21,6 +21,7 @@ export interface HintProps extends BoxProps {
   children?: React.ReactNode
   defaultOpen?: boolean
   modal?: boolean
+  onAnchorFound?: () => void
   onOpenChange?: (open: boolean) => void
   open?: boolean
   side?: SideValue
@@ -37,6 +38,7 @@ export function Hint({
   css = {},
   defaultOpen = true,
   modal = false,
+  onAnchorFound,
   onOpenChange = () => {},
   open,
   part,
@@ -57,6 +59,7 @@ export function Hint({
       align,
       alignOffset,
       anchor,
+      onAnchorFound,
       onOpenChange: (newOpen) => {
         onOpenChange(newOpen)
 

--- a/packages/react/src/components/Hint/index.tsx
+++ b/packages/react/src/components/Hint/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { Box, type BoxProps } from '@/components/Box'
 import { Overlay } from '@/components/Overlay'
@@ -21,7 +21,7 @@ export interface HintProps extends BoxProps {
   children?: React.ReactNode
   defaultOpen?: boolean
   modal?: boolean
-  onAnchorFound?: () => void
+  onMount?: () => void
   onOpenChange?: (open: boolean) => void
   open?: boolean
   side?: SideValue
@@ -38,7 +38,7 @@ export function Hint({
   css = {},
   defaultOpen = true,
   modal = false,
-  onAnchorFound,
+  onMount,
   onOpenChange = () => {},
   open,
   part,
@@ -59,7 +59,6 @@ export function Hint({
       align,
       alignOffset,
       anchor,
-      onAnchorFound,
       onOpenChange: (newOpen) => {
         onOpenChange(newOpen)
 
@@ -76,6 +75,7 @@ export function Hint({
   const referenceProps = getReferenceProps()
 
   const { isVisible } = useVisibility(refs.reference.current as Element | null)
+  const isMounted = useRef(false)
 
   useEffect(() => {
     if (!scrollComplete && autoScroll && refs.reference.current instanceof Element) {
@@ -108,8 +108,14 @@ export function Hint({
     }
   }, [autoScroll, refs.reference, scrollComplete])
 
-  if (refs.reference.current == null || !scrollComplete || !isVisible) {
+  const shouldMount = refs.reference.current !== null && scrollComplete && isVisible
+
+  if (!shouldMount) {
+    isMounted.current = false
     return null
+  } else if (isMounted.current === false) {
+    isMounted.current = true
+    onMount?.()
   }
 
   return (

--- a/packages/react/src/components/Hint/useFloatingHint.ts
+++ b/packages/react/src/components/Hint/useFloatingHint.ts
@@ -23,7 +23,6 @@ import { useMutationAwareAnchor } from '@/components/Hint/useMutationAwareAnchor
 
 export interface FloatingHintProps extends HintProps {
   onOpenChange?: UseFloatingOptions['onOpenChange']
-  onAnchorFound?: () => void
   open: boolean
 }
 
@@ -52,7 +51,6 @@ export function useFloatingHint({
   alignOffset,
   anchor,
   onOpenChange = () => {},
-  onAnchorFound,
   open,
   side,
   sideOffset,
@@ -108,11 +106,10 @@ export function useFloatingHint({
   useEffect(() => {
     if (anchorElement != null) {
       refs.setReference(anchorElement)
-      onAnchorFound?.()
     } else {
       console.debug(`[frigade] Hint: No anchor found for selector: ${anchor}`)
     }
-  }, [anchor, anchorElement, refs, onAnchorFound])
+  }, [anchor, anchorElement, refs])
 
   // The flip() middleware might reverse the align prop
   const finalPlacement = computedPlacement.split('-')

--- a/packages/react/src/components/Hint/useFloatingHint.ts
+++ b/packages/react/src/components/Hint/useFloatingHint.ts
@@ -23,6 +23,7 @@ import { useMutationAwareAnchor } from '@/components/Hint/useMutationAwareAnchor
 
 export interface FloatingHintProps extends HintProps {
   onOpenChange?: UseFloatingOptions['onOpenChange']
+  onAnchorFound?: () => void
   open: boolean
 }
 
@@ -51,6 +52,7 @@ export function useFloatingHint({
   alignOffset,
   anchor,
   onOpenChange = () => {},
+  onAnchorFound,
   open,
   side,
   sideOffset,
@@ -106,10 +108,11 @@ export function useFloatingHint({
   useEffect(() => {
     if (anchorElement != null) {
       refs.setReference(anchorElement)
+      onAnchorFound?.()
     } else {
       console.debug(`[frigade] Hint: No anchor found for selector: ${anchor}`)
     }
-  }, [anchor, anchorElement, refs])
+  }, [anchor, anchorElement, refs, onAnchorFound])
 
   // The flip() middleware might reverse the align prop
   const finalPlacement = computedPlacement.split('-')

--- a/packages/react/src/components/Tour/Tour.tsx
+++ b/packages/react/src/components/Tour/Tour.tsx
@@ -74,7 +74,7 @@ export function Tour({ as, flowId, ...props }: TourProps) {
   const { onDismiss, onPrimary, onSecondary } = props
 
   return (
-    <Flow as={null} flowId={flowId} {...props}>
+    <Flow as={null} flowId={flowId} autoStart={false} {...props}>
       {({ flow, handleDismiss, parentProps, step }) => {
         const {
           align = 'after',

--- a/packages/react/src/components/Tour/TourStep.tsx
+++ b/packages/react/src/components/Tour/TourStep.tsx
@@ -68,7 +68,7 @@ export function TourStep({
       side={side}
       sideOffset={sideOffset}
       spotlight={spotlight}
-      onAnchorFound={() => {
+      onMount={() => {
         if (defaultOpen && !disabled) {
           step?.start()
         }

--- a/packages/react/src/components/Tour/TourStep.tsx
+++ b/packages/react/src/components/Tour/TourStep.tsx
@@ -68,6 +68,11 @@ export function TourStep({
       side={side}
       sideOffset={sideOffset}
       spotlight={spotlight}
+      onAnchorFound={() => {
+        if (defaultOpen && !disabled) {
+          step?.start()
+        }
+      }}
       {...otherProps}
     >
       <Card


### PR DESCRIPTION
Ensures that we do not mark a tour started until the anchor shows up.

Testing done:
- Added a storybook story to ensure that we don't make a tour started until the anchor shows up 
- Tested existing tour/hint stories
- All tour integration tests pass