### PR TITLE
feat: debounce url change calls

### DIFF
--- a/.changeset/old-years-ring.md
+++ b/.changeset/old-years-ring.md
@@ -1,0 +1,6 @@
+---
+"@frigade/js": minor
+"@frigade/react": minor
+---
+
+Performance improvement that updates the behavior of `syncOnWindowUpdates` to debounce identical calls more aggressively

--- a/packages/js-api/src/core/types.ts
+++ b/packages/js-api/src/core/types.ts
@@ -337,6 +337,11 @@ export interface FrigadeConfig {
    * @ignore Internal use only.
    */
   __platformName?: string
+
+  /**
+   * @ignore Internal use only.
+   */
+  __refreshIntervalInMS: number
 }
 
 export interface StatefulStep {

--- a/packages/js-api/src/shared/fetchable.ts
+++ b/packages/js-api/src/shared/fetchable.ts
@@ -9,6 +9,7 @@ export class Fetchable {
     userId: generateGuestId(),
     __instanceId: Math.random().toString(12).substring(4),
     generateGuestId: true,
+    __refreshIntervalInMS: 100,
   }
 
   constructor(config: FrigadeConfig) {
@@ -22,24 +23,16 @@ export class Fetchable {
   /**
    * @ignore
    */
-  public async fetch(
-    path: string,
-    options?: Record<any, any>,
-    cancelPendingRequests: boolean = false
-  ) {
+  public async fetch(path: string, options?: Record<any, any>) {
     if (this.config.__readOnly) {
       return getEmptyResponse()
     }
 
-    return gracefulFetch(
-      this.getAPIUrl(path),
-      {
-        keepalive: true,
-        ...(options ?? {}),
-        ...getHeaders(this.config),
-      },
-      cancelPendingRequests
-    )
+    return gracefulFetch(this.getAPIUrl(path), {
+      keepalive: true,
+      ...(options ?? {}),
+      ...getHeaders(this.config),
+    })
   }
 
   private getAPIUrl(path: string) {

--- a/packages/js-api/src/shared/utils.ts
+++ b/packages/js-api/src/shared/utils.ts
@@ -120,11 +120,7 @@ class CallQueue {
 
 globalThis.callQueue = new CallQueue()
 
-export async function gracefulFetch(
-  url: string,
-  options: any,
-  cancelPendingRequests: boolean = false
-) {
+export async function gracefulFetch(url: string, options: any) {
   if (typeof globalThis.fetch !== 'function') {
     return getEmptyResponse(
       "- Attempted to call fetch() in an environment that doesn't support it."
@@ -136,7 +132,7 @@ export async function gracefulFetch(
 
   const isWebPostRequest = isWeb() && options && options.body && options.method === 'POST'
 
-  if (isWebPostRequest && !cancelPendingRequests) {
+  if (isWebPostRequest) {
     const cachedCall = globalThis.callQueue.hasIdenticalRecentCall(lastCallDataKey)
 
     if (cachedCall != null && cachedCall.response != null) {
@@ -148,11 +144,6 @@ export async function gracefulFetch(
 
   if (!response) {
     try {
-      // TEMP: Disable pending request flushing
-      // if (cancelPendingRequests) {
-      //   globalThis.callQueue.cancelAllPendingRequests()
-      // }
-
       const pendingResponse = fetch(url, options)
 
       if (isWebPostRequest) {


### PR DESCRIPTION
Performance improvement that updates the behavior of `syncOnWindowUpdates` to debounce identical calls more aggressively. We set the default value to every 100ms but make it configurable via an internal prop.

Verified all existing storybook tests pass