### PR TITLE
fix: remove optimistic writes from collections

### DIFF
--- a/apps/smithy/src/stories/Collection/Collection.stories.tsx
+++ b/apps/smithy/src/stories/Collection/Collection.stories.tsx
@@ -176,7 +176,7 @@ export const MultipleAnnouncements = {
         <Collection collectionId="collection_49A28miL" />
 
         {/* Storybook X & Y Announcements */}
-        <Collection collectionId="collection_DrlkZoXK" />
+        {/* <Collection collectionId="collection_DrlkZoXK" /> */}
       </>
     ),
   ],

--- a/packages/js-api/src/core/collections.ts
+++ b/packages/js-api/src/core/collections.ts
@@ -90,15 +90,15 @@ export class Collections {
 
     for (const [collectionId, collection] of previousCollections) {
       const newCollection = newCollections.get(collectionId)
-      if (collection.flows.length !== newCollection.flows.length) {
+      if (collection?.flows?.length !== newCollection?.flows?.length) {
         this.hasChanges = true
         break
       }
 
       for (let i = 0; i < collection.flows.length; i++) {
         if (
-          collection.flows[i].flowId !== newCollection.flows[i].flowId ||
-          collection.flows[i].visible !== newCollection.flows[i].visible
+          collection?.flows[i]?.flowId !== newCollection?.flows[i]?.flowId ||
+          collection?.flows[i]?.visible !== newCollection?.flows[i]?.visible
         ) {
           this.hasChanges = true
           break

--- a/packages/js-api/src/core/flow.ts
+++ b/packages/js-api/src/core/flow.ts
@@ -621,6 +621,8 @@ export class Flow extends Fetchable {
     copy.$state.started = true
     copy.$state.visible = false
     this.getGlobalState().flowStates[this.id] = copy
+    // Temporarily disable collections until server round trip has finished
+    this.getGlobalState().collections.ingestCollectionsData(new Map())
     this.resyncState()
   }
 
@@ -631,6 +633,8 @@ export class Flow extends Fetchable {
     const copy = clone(this.getGlobalState().flowStates[this.id])
     copy.$state.started = true
     this.getGlobalState().flowStates[this.id] = copy
+    // Temporarily disable collections until server round trip has finished
+    this.getGlobalState().collections.ingestCollectionsData(new Map())
     this.resyncState()
   }
 
@@ -676,6 +680,8 @@ export class Flow extends Fetchable {
     copy.$state.skipped = true
     copy.$state.visible = false
     this.getGlobalState().flowStates[this.id] = copy
+    // Temporarily disable collections until server round trip has finished
+    this.getGlobalState().collections.ingestCollectionsData(new Map())
     this.resyncState()
   }
 

--- a/packages/react/src/hooks/useCollections.ts
+++ b/packages/react/src/hooks/useCollections.ts
@@ -30,17 +30,11 @@ export function useCollections() {
           cb()
         }, 0)
       }
-      
-    frigade?.on('flow.any', handler)
 
-    return () => {
-      frigade?.off('flow.any', handler)
-    }
-
-      frigade?.onStateChange(handler)
+      frigade?.on('flow.any', handler)
 
       return () => {
-        frigade?.removeStateChangeHandler(handler)
+        frigade?.off('flow.any', handler)
       }
     },
     [frigade]


### PR DESCRIPTION
Temporarily sets list of collection flows to empty while server-roundtrip for completed/dismissed/restarted flows continues. This is done in order to avoid the race condition where the frontend thinks it should render the next flow while in fact it should be in cool-off.

Testing done:
Reproduced the bug in the story "Multiple Announcements" and ensured it was fixed after applying the fix. Also tested existing collection integration tests.