### PR TITLE
fix: frigade has not been initialized error

### DIFF
--- a/.changeset/itchy-plums-destroy.md
+++ b/.changeset/itchy-plums-destroy.md
@@ -1,0 +1,6 @@
+---
+"@frigade/js": patch
+"@frigade/react": patch
+---
+
+Fixes an edge case where in some cases, the error `Frigade has not yet been initialized` can occur.

--- a/packages/js-api/src/core/frigade.ts
+++ b/packages/js-api/src/core/frigade.ts
@@ -72,6 +72,10 @@ export class Frigade extends Fetchable {
    * @ignore
    */
   private queueRefreshStateFromAPI() {
+    if (!this.isReady()) {
+      return
+    }
+
     this.queuedRefresh = true
     if (this.refreshTimeout) {
       return
@@ -280,7 +284,12 @@ export class Frigade extends Fetchable {
    * @ignore
    */
   public isReady(): boolean {
-    return Boolean(this.config.__instanceId && this.config.apiKey && this.initPromise)
+    return Boolean(
+      this.config.__instanceId &&
+        this.config.apiKey &&
+        this.initPromise &&
+        frigadeGlobalState[getGlobalStateKey(this.config)]
+    )
   }
 
   /**


### PR DESCRIPTION
The issue seems to occur when rapidly changing a URL while Frigade is initializing.