### PR TITLE
fix: bump @frigade/js to ^0.9.7 in @frigade/react

### DIFF
--- a/.changeset/bump-react-js-dep.md
+++ b/.changeset/bump-react-js-dep.md
@@ -1,5 +1,0 @@
----
-"@frigade/react": patch
----
-
-Bump @frigade/js to ^0.9.7 to include the fix for sending STARTED_STEP events when completing a step.

--- a/.changeset/bump-react-js-dep.md
+++ b/.changeset/bump-react-js-dep.md
@@ -1,0 +1,5 @@
+---
+"@frigade/react": patch
+---
+
+Bump @frigade/js to ^0.9.7 to include the fix for sending STARTED_STEP events when completing a step.

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @frigade/react
 
+## 2.10.3
+
+### Patch Changes
+
+- e5c3939: Bump @frigade/js to ^0.9.7 to include the fix for sending STARTED_STEP events when completing a step.
+
 ## 2.10.2
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frigade/react",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "description": "Build better product onboarding, faster.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@floating-ui/react": "^0.26.22",
-    "@frigade/js": "^0.9.6",
+    "@frigade/js": "^0.9.7",
     "@radix-ui/react-checkbox": "^1.1.1",
     "@radix-ui/react-collapsible": "^1.0.3",
     "@radix-ui/react-dialog": "^1.0.5",


### PR DESCRIPTION
Picks up the STARTED_STEP fix from @frigade/js@0.9.7.

Made-with: Cursor