### PR TITLE
fix: skip all API calls when generateGuestId is false and no userId is provided

### DIFF
--- a/.changeset/nervous-shrimps-behave.md
+++ b/.changeset/nervous-shrimps-behave.md
@@ -1,0 +1,5 @@
+---
+'@frigade/js': patch
+---
+
+Skip all Frigade API requests when `generateGuestId` is set to `false` and no `userId` has been provided. Previously the SDK would still send a `flowStates` request with an auto-generated guest ID on initialization, page navigation, and tab focus.

--- a/packages/js-api/src/core/frigade.ts
+++ b/packages/js-api/src/core/frigade.ts
@@ -562,7 +562,7 @@ export class Frigade extends Fetchable {
       frigadeGlobalState[globalStateKey].refreshStateFromAPI = async (
         overrideFlowStateRaw?: FlowStates
       ) => {
-        if (this.config.__readOnly) {
+        if (this.config.__readOnly || this.isAnonymousWithGuestIdDisabled()) {
           return
         }
 

--- a/packages/js-api/src/shared/fetchable.ts
+++ b/packages/js-api/src/shared/fetchable.ts
@@ -1,4 +1,10 @@
-import { generateGuestId, getEmptyResponse, getHeaders, gracefulFetch } from './utils'
+import {
+  generateGuestId,
+  getEmptyResponse,
+  getHeaders,
+  gracefulFetch,
+  GUEST_PREFIX,
+} from './utils'
 import { DEFAULT_REFRESH_INTERVAL_IN_MS, FrigadeConfig } from '../core/types'
 import { frigadeGlobalState, FrigadeGlobalState, getGlobalStateKey } from './state'
 
@@ -24,7 +30,7 @@ export class Fetchable {
    * @ignore
    */
   public async fetch(path: string, options?: Record<any, any>) {
-    if (this.config.__readOnly) {
+    if (this.config.__readOnly || this.isAnonymousWithGuestIdDisabled()) {
       return getEmptyResponse()
     }
 
@@ -37,6 +43,18 @@ export class Fetchable {
 
   private getAPIUrl(path: string) {
     return `${this.config.apiUrl.replace(/\/$/, '')}/${path.replace(/^\//, '')}`
+  }
+
+  /**
+   * @ignore
+   * True when `generateGuestId` is explicitly disabled and no real userId has been provided,
+   * in which case no requests should be sent to the Frigade API.
+   */
+  protected isAnonymousWithGuestIdDisabled(): boolean {
+    return (
+      this.config.generateGuestId === false &&
+      (!this.config.userId || this.config.userId.startsWith(GUEST_PREFIX))
+    )
   }
 
   /**


### PR DESCRIPTION
## Summary

When `generateGuestId` is set to `false` and no `userId` is provided, the SDK previously still sent a `POST /v1/public/flowStates` request with an auto-generated guest ID on initialization, page navigation, and tab focus. This contradicted the prop's documented behavior ("Frigade will not initialize or render any Flows until a userId is provided") and generated API traffic for anonymous visitors.

- Added a guard in `Fetchable.fetch()` that skips all API requests when `generateGuestId === false` and the effective userId is missing or a `guest_` ID. Since every request (flowStates, sessions, flow responses, tracking) goes through this method, this covers the full surface.
- The `flowStates` refresh closure also returns early in this mode so the skipped request isn't misreported by `hasFailedToLoad()`.
- Global state is still initialized, so `isReady()` remains true and calling `identify()` with a real userId resumes normal behavior.

## Test plan

- [x] Existing integration test `can disable guest id generation` passes (no flows anonymously → `identify()` → flows load)
- [x] Verified with a mocked `fetch` that zero requests occur with `generateGuestId: false` and no userId, and that requests resume after `identify()`
- [x] Typecheck passes

Made with [Cursor](https://cursor.com)