### PR TITLE
chore: bump @frigade/js to 0.9.9 in @frigade/react

### DIFF
--- a/.changeset/lucky-pandas-drive.md
+++ b/.changeset/lucky-pandas-drive.md
@@ -1,0 +1,5 @@
+---
+'@frigade/react': patch
+---
+
+Bump `@frigade/js` to 0.9.9 to pick up the fix that skips all Frigade API requests when `generateGuestId` is `false` and no `userId` has been provided

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@floating-ui/react": "^0.26.22",
-    "@frigade/js": "^0.9.8",
+    "@frigade/js": "^0.9.9",
     "@radix-ui/react-checkbox": "^1.1.1",
     "@radix-ui/react-collapsible": "^1.0.3",
     "@radix-ui/react-dialog": "^1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3970,7 +3970,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@frigade/js@npm:^0.9.8, @frigade/js@workspace:packages/js-api":
+"@frigade/js@npm:^0.9.9, @frigade/js@workspace:packages/js-api":
   version: 0.0.0-use.local
   resolution: "@frigade/js@workspace:packages/js-api"
   dependencies:
@@ -4004,7 +4004,7 @@ __metadata:
   dependencies:
     "@emotion/react": "npm:^11.14.0"
     "@floating-ui/react": "npm:^0.26.22"
-    "@frigade/js": "npm:^0.9.8"
+    "@frigade/js": "npm:^0.9.9"
     "@radix-ui/react-checkbox": "npm:^1.1.1"
     "@radix-ui/react-collapsible": "npm:^1.0.3"
     "@radix-ui/react-dialog": "npm:^1.0.5"


### PR DESCRIPTION
## Summary

- Bumps the `@frigade/js` dependency in `@frigade/react` to `^0.9.9`, which includes the fix that skips all API requests when `generateGuestId` is `false` and no `userId` has been provided (#508).
- Adds a patch changeset for `@frigade/react` so a new version is published with the updated dependency. The automatic Version Packages run didn't bump React since 0.9.9 still satisfied the previous `^0.9.8` range.

## Test plan

- [x] `yarn install` succeeds with the updated range (workspace resolution unchanged)

Made with [Cursor](https://cursor.com)