### PR TITLE
fix: never create guest IDs when generateGuestId is false; resolve useFlow loading state

### DIFF
--- a/.changeset/brave-donuts-listen.md
+++ b/.changeset/brave-donuts-listen.md
@@ -1,0 +1,6 @@
+---
+'@frigade/js': patch
+'@frigade/react': patch
+---
+
+When `generateGuestId` is `false` and no `userId` has been provided, the SDK no longer generates or persists a guest ID at all (previously one was still created and stored in localStorage), and `useFlow` now resolves with `isLoading: false` instead of staying in a loading state forever.

--- a/packages/js-api/src/core/frigade.ts
+++ b/packages/js-api/src/core/frigade.ts
@@ -170,12 +170,15 @@ export class Frigade extends Fetchable {
       ...config,
     })
 
-    if (!this.config.userId) {
+    // Without a userId we can't initialize, unless guest IDs are explicitly
+    // disabled: in that case we still set up local state (without making any
+    // API calls) so that getters and hooks resolve instead of hanging.
+    if (!this.config.userId && this.config.generateGuestId !== false) {
       return
     }
 
     this.initPromise = (async () => {
-      if (!this.config.__readOnly) {
+      if (!this.config.__readOnly && this.config.userId) {
         if (this.config.userId?.startsWith(GUEST_PREFIX)) {
           // do nothing
         } else if (this.config.userId && this.config.groupId) {
@@ -314,11 +317,7 @@ export class Frigade extends Fetchable {
    * @param flowId
    */
   public async getFlow(flowId: string) {
-    if (
-      this.getConfig().generateGuestId === false &&
-      this.getConfig().userId &&
-      this.getConfig().userId.startsWith(GUEST_PREFIX)
-    ) {
+    if (this.isAnonymousWithGuestIdDisabled()) {
       return undefined
     }
     await this.initIfNeeded()
@@ -335,10 +334,7 @@ export class Frigade extends Fetchable {
 
   public async getFlows() {
     await this.initIfNeeded()
-    if (
-      this.config.generateGuestId === false &&
-      this.getConfig().userId?.startsWith(GUEST_PREFIX)
-    ) {
+    if (this.isAnonymousWithGuestIdDisabled()) {
       return []
     }
     return this.flows
@@ -398,7 +394,7 @@ export class Frigade extends Fetchable {
   public async getCollections(): Promise<CollectionsList | undefined> {
     await this.initIfNeeded()
 
-    if (!this.config.userId && this.config.generateGuestId === false) {
+    if (this.isAnonymousWithGuestIdDisabled()) {
       return undefined
     }
 

--- a/packages/js-api/src/shared/fetchable.ts
+++ b/packages/js-api/src/shared/fetchable.ts
@@ -12,7 +12,6 @@ export class Fetchable {
   public config: FrigadeConfig = {
     apiKey: '',
     apiUrl: 'https://api.frigade.com',
-    userId: generateGuestId(),
     __instanceId: Math.random().toString(12).substring(4),
     generateGuestId: true,
     __refreshIntervalInMS: DEFAULT_REFRESH_INTERVAL_IN_MS,
@@ -23,6 +22,13 @@ export class Fetchable {
     this.config = {
       ...this.config,
       ...filteredConfig,
+    }
+
+    // Only generate (and persist) a guest ID when guest IDs are enabled.
+    // When generateGuestId is explicitly false, the userId stays undefined
+    // until the consumer provides one.
+    if (!this.config.userId && this.config.generateGuestId !== false) {
+      this.config.userId = generateGuestId()
     }
   }
 
@@ -46,11 +52,10 @@ export class Fetchable {
   }
 
   /**
-   * @ignore
    * True when `generateGuestId` is explicitly disabled and no real userId has been provided,
-   * in which case no requests should be sent to the Frigade API.
+   * in which case no requests are sent to the Frigade API and no Flows are returned.
    */
-  protected isAnonymousWithGuestIdDisabled(): boolean {
+  public isAnonymousWithGuestIdDisabled(): boolean {
     return (
       this.config.generateGuestId === false &&
       (!this.config.userId || this.config.userId.startsWith(GUEST_PREFIX))

--- a/packages/js-api/test/frigade.int.test.ts
+++ b/packages/js-api/test/frigade.int.test.ts
@@ -18,16 +18,26 @@ describe('Basic Checklist integration test', () => {
   })
 
   test('can disable guest id generation', async () => {
+    window.localStorage.clear()
+    const fetchSpy = jest.spyOn(globalThis, 'fetch')
     const frigade = new Frigade(testAPIKey, {
       generateGuestId: false,
     })
     let flows = await frigade.getFlows()
     expect(flows.length).toEqual(0)
     expect(frigade.isReady()).toBeTruthy()
+    expect(frigade.isAnonymousWithGuestIdDisabled()).toBeTruthy()
+    // No guest ID should be generated or persisted
+    expect(frigade.getConfig().userId).toBeUndefined()
+    expect(window.localStorage.getItem('frigade-guest-key')).toBeNull()
+    // And no API calls should have been made
+    expect(fetchSpy).not.toHaveBeenCalled()
+    fetchSpy.mockRestore()
     await frigade.identify(getRandomID())
     flows = await frigade.getFlows()
     expect(flows.length).toBeGreaterThan(0)
     expect(frigade.isReady()).toBeTruthy()
+    expect(frigade.isAnonymousWithGuestIdDisabled()).toBeFalsy()
   })
 
   test('flows have fields set', async () => {

--- a/packages/react/src/hooks/useFlow.ts
+++ b/packages/react/src/hooks/useFlow.ts
@@ -68,8 +68,12 @@ export function useFlow(
     })
   }, [config?.variables, flow, flowId, variables])
 
+  // When guest IDs are disabled and no userId has been provided yet, no Flow
+  // will ever load: resolve immediately instead of staying in a loading state.
+  const willNeverLoad = frigade?.hasFailedToLoad() || frigade?.isAnonymousWithGuestIdDisabled()
+
   return {
     flow,
-    isLoading: frigade?.hasFailedToLoad() ? false : !flow,
+    isLoading: willNeverLoad ? false : !flow,
   }
 }


### PR DESCRIPTION
## Summary

Fixes two customer-reported issues with `generateGuestId={false}`:

**1. A guest ID was still being created client-side.** The SDK generated a `guest_<uuid>` as the default `userId` and persisted it to `localStorage` regardless of the flag (and on SDK versions before `@frigade/js@0.9.9`, that guest ID was also sent to the API). The guest ID is now only generated when guest IDs are enabled; with the flag off and no `userId`, the config's `userId` stays `undefined` and nothing is written to `localStorage`. Note: customers on `@frigade/react` 2.10.5 or older lockfiles may still be pinned to `@frigade/js` 0.9.8, which sent guest `flowStates`/`sessions` requests — upgrading picks up both fixes.

**2. `useFlow` never resolved for anonymous users.** With the flag off and no user logged in, `isLoading` stayed `true` forever since no Flow would ever arrive. `init()` now still sets up local state (without any API calls) so `isReady()` and `getGlobalState()` work, `isAnonymousWithGuestIdDisabled()` is exposed publicly, and `useFlow` returns `flow: undefined` with `isLoading: false` in this state.

Also consolidated the scattered `generateGuestId === false` checks in `getFlow`/`getFlows`/`getCollections` onto the shared helper (which now also covers the undefined-userId case).

Providing a `userId` (at render time or later via `identify()`) restores full behavior, covered by the extended integration test.

## Test plan

- [x] Full js-api integration suite passes (23/23)
- [x] Extended `can disable guest id generation` test: asserts `userId` is `undefined`, no `frigade-guest-key` in localStorage, zero `fetch` calls while anonymous, and flows load after `identify()`
- [x] Typecheck and build pass for both `@frigade/js` and `@frigade/react`

Made with [Cursor](https://cursor.com)